### PR TITLE
Fix bug wherein program crashes if ./data folder doesn't exist

### DIFF
--- a/shift.py
+++ b/shift.py
@@ -143,6 +143,11 @@ class ShiftClient:
         return status
 
     def __save_cookie(self):
+        """Make ./data folder if not present"""
+        from os import path, mkdir
+        if not path.exists(path.dirname(self.cookie_file)):
+            mkdir(path.dirname(self.cookie_file))
+
         """Save cookie for auto login"""
         with open(self.cookie_file, "wb") as f:
             for cookie in self.client.cookies:


### PR DESCRIPTION
If `./data` is not present, the program will crash. I'm aware there's already a commit that should've fixed this issue (https://github.com/Fabbi/autoshift/commit/49fd5597780b670035c44bc6cd1b5703ade3d57c), but nevertheless the issue persists. Instead I suggest you check for the folder when creating the cookie file, and if not present, create the folder then.